### PR TITLE
fix removal of heatmap layer

### DIFF
--- a/lib/HeatmapLayer.js
+++ b/lib/HeatmapLayer.js
@@ -76,6 +76,15 @@ function isValid(num) {
   return !isInvalid(num);
 }
 
+function safeRemoveLayer(map, el) {
+  var _map$getPanes = map.getPanes(),
+      overlayPane = _map$getPanes.overlayPane;
+
+  if (overlayPane.contains(el)) {
+    overlayPane.removeChild(el);
+  }
+}
+
 function shouldIgnoreLocation(loc) {
   return isInvalid(loc.lng) || isInvalid(loc.lat);
 }
@@ -124,7 +133,7 @@ var HeatmapLayer = function (_MapLayer) {
         return this;
       },
       onRemove: function onRemove(map) {
-        map.getPanes().overlayPane.removeChild(el);
+        safeRemoveLayer(map, el);
       }
     });
 
@@ -191,7 +200,7 @@ var HeatmapLayer = function (_MapLayer) {
   };
 
   HeatmapLayer.prototype.componentWillUnmount = function componentWillUnmount() {
-    this.context.map.getPanes().overlayPane.removeChild(this._el);
+    safeRemoveLayer(this.context.map, this._el);
   };
 
   HeatmapLayer.prototype.fitBounds = function fitBounds() {

--- a/package.json
+++ b/package.json
@@ -28,10 +28,10 @@
   "author": "Jeremiah Hall <npm@jeremiahrhall.com>",
   "license": "MIT",
   "peerDependencies": {
-    "leaflet": "^1.0.2",
-    "react-leaflet": "^1.0.0",
-    "react": "^15.4.1",
-    "react-dom": "^15.4.1"
+    "leaflet": ">=1.0.0",
+    "react-leaflet": ">=1.0.0",
+    "react": ">=15.4.1",
+    "react-dom": ">=15.4.1"
   },
   "devDependencies": {
     "babel-cli": "^6.6.5",

--- a/src/HeatmapLayer.js
+++ b/src/HeatmapLayer.js
@@ -65,6 +65,13 @@ function isValid(num: number): boolean {
   return !isInvalid(num);
 }
 
+function safeRemoveLayer (map, el) {
+  const {overlayPane} = map.getPanes()
+  if (overlayPane.contains(el)) {
+    overlayPane.removeChild(el);
+  }
+}
+
 function shouldIgnoreLocation(loc: LngLat): boolean {
   return isInvalid(loc.lng) || isInvalid(loc.lat);
 }
@@ -125,7 +132,7 @@ export default class HeatmapLayer extends MapLayer {
         return this;
       },
       onRemove: function(map) {
-        map.getPanes().overlayPane.removeChild(el);
+        safeRemoveLayer(map, el)
       }
     });
 
@@ -194,7 +201,7 @@ export default class HeatmapLayer extends MapLayer {
   }
 
   componentWillUnmount(): void {
-    this.context.map.getPanes().overlayPane.removeChild(this._el);
+    safeRemoveLayer(this.context.map, this._el);
   }
 
   fitBounds(): void {


### PR DESCRIPTION
before, whenever a react-leaflet map was unmounted, the heatmap Layer’s
onRemove function and the component’s componentWillUnmount would get
called.  This caused an error since the node had already been removed
from the DOM.